### PR TITLE
Make debian-venti more usable for gravity-buildbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ debian-venti:
 	docker import \
 		--change 'ENV DEBIAN_FRONTEND noninteractive' \
 		--change 'ENV GOROOT /go' \
-		--change 'ENV GOPATH /gocode' \
-		--change 'ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/go/bin:/gocode/bin' \
+		--change 'ENV GOPATH /gopath' \
+		--change 'ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/go/bin:/gopath/bin' \
 		venti.tar debian-venti:$(DEBIAN_VENTI_VERSION)
 
 .PHONY: syntax-check

--- a/venti/build.sh
+++ b/venti/build.sh
@@ -34,7 +34,7 @@ function bootstrap {
     # Setup golang building environment and godep
     curl -o go-linux.tar.gz -L "$GOLANG_URL"
     tar -xf go-linux.tar.gz -C "$ROOTFS"
-    chroot "$ROOTFS" /bin/bash -c 'GOROOT=/go GOPATH=/gocode PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/go/bin go get github.com/tools/godep'
+    chroot "$ROOTFS" /bin/bash -c 'GOROOT=/go GOPATH=/gopath PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/go/bin go get github.com/tools/godep'
 
     cp -r -t "$ROOTFS" "$SCRIPT_DIR"/rootfs/*
 

--- a/venti/config
+++ b/venti/config
@@ -4,4 +4,4 @@ FLAVOUR=${FLAVOUR:-minimal}
 DUMBINIT_URL=${DUMBINIT_URL:-https://github.com/Yelp/dumb-init/releases/download/v1.0.3/dumb-init_1.0.3_amd64.deb}
 GOLANG_URL=${GOLANG_URL:-https://storage.googleapis.com/golang/go1.5.4.linux-amd64.tar.gz}
 TMPFS_SIZE=${TMPFS_SIZE:-1073741824}
-BOOTSTRAP_INCLUDE=${BOOTSTRAP_INCLUDE:-ca-certificates,less,locales,inetutils-ping,iproute2,git,gcc,make,python,apt-transport-https,iptables,curl,openssh-client,vim-tiny,sudo}
+BOOTSTRAP_INCLUDE=${BOOTSTRAP_INCLUDE:-ca-certificates,less,locales,inetutils-ping,iproute2,git,gcc,make,python,apt-transport-https,iptables,curl,openssh-client,vim-tiny,sudo,libc6-dev}


### PR DESCRIPTION
Add libc6-dev and change GOPATH to more obvious /gopath
