### PR TITLE
Add separate Go debian-venti images with different Go versions.

### DIFF
--- a/venti/Dockerfile
+++ b/venti/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian-venti:jessie
+MAINTAINER Gravitational Inc <ops@gravitational.com>
+
+ARG GOVERSION=1.5.4
+
+ENV GOROOT=/go \
+    GOPATH=/gopath \
+    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/go/bin
+
+RUN ( \
+        curl -o /go-linux.tar.gz -L https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz && \
+        tar -xf /go-linux.tar.gz -C / && \
+        go get github.com/tools/godep && \
+        rm /go-linux.tar.gz ; \
+    )
+

--- a/venti/build.sh
+++ b/venti/build.sh
@@ -37,11 +37,6 @@ function bootstrap {
     # Installing useful Python modules
     chroot "$ROOTFS" /bin/bash -c 'pip install awscli'
 
-    # Setup golang building environment and godep
-    curl -o go-linux.tar.gz -L "$GOLANG_URL"
-    tar -xf go-linux.tar.gz -C "$ROOTFS"
-    chroot "$ROOTFS" /bin/bash -c 'GOROOT=/go GOPATH=/gopath PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/go/bin go get github.com/tools/godep'
-
     cp -r -t "$ROOTFS" "$SCRIPT_DIR"/rootfs/*
 
     # Install docker

--- a/venti/config
+++ b/venti/config
@@ -2,5 +2,4 @@ SUITE=${SUITE:-jessie}
 MIRROR=${MIRROR:-http://httpredir.debian.org/debian}
 FLAVOUR=${FLAVOUR:-minimal}
 DUMBINIT_URL=${DUMBINIT_URL:-https://github.com/Yelp/dumb-init/releases/download/v1.0.3/dumb-init_1.0.3_amd64.deb}
-GOLANG_URL=${GOLANG_URL:-https://storage.googleapis.com/golang/go1.5.4.linux-amd64.tar.gz}
 PKG_INCLUDE=${PKG_INCLUDE:-apt-transport-https ca-certificates curl gcc git inetutils-ping iproute2 iptables less libc6-dev locales make openssh-client psmisc python python-dev python-pip rsync sudo unzip vim-tiny wget}


### PR DESCRIPTION
- Use tag jessie instead of 0.0.1 for each type of images
- Add 1.5.4, 1.6.3 and 1.7 debian-venti images
- debian-venti:0.0.1 and debian-venti:latest points to debian-venti:go1.5.4-jessie
  for compatibility
