### PR TITLE
Go version fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /*.tar
+go-versions.txt

--- a/get_golang_versions.sh
+++ b/get_golang_versions.sh
@@ -58,6 +58,7 @@ if version_gt $bash_version 4.3; then
 else
     read -a releases_list <<< $(wget -qO- https://golang.org/dl/ | grep -oP 'https:\/\/dl\.google\.com\/go\/go([0-9\.]+)\.linux-amd64\.tar\.gz' | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p' | uniq )
 fi
+[[ ${#releases_list[@]} -lt 3 ]] && { >&2 echo "parse error: not enough releases found on https://golang.org/dl/"; exit 1; }
 
 latest_release=${releases_list[0]}
 latest_major_release=$(cut -d '.' -f 1 <<< ${releases_list[0]})"."$(cut -d . -f 2 <<< ${releases_list[0]})

--- a/get_golang_versions.sh
+++ b/get_golang_versions.sh
@@ -54,9 +54,9 @@ function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$
 
 bash_version=$(echo $BASH_VERSION | cut -d '.' -f 1,2)
 if version_gt $bash_version 4.3; then
-    readarray releases_list <<< $(wget -qO- https://golang.org/dl/ | grep -oP 'https:\/\/dl\.google\.com\/go\/go([0-9\.]+)\.linux-amd64\.tar\.gz' | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p' | uniq )
+    readarray releases_list <<< $(wget -qO- https://golang.org/dl/ | grep -oP '\/dl/go([0-9\.]+)\.linux-amd64\.tar\.gz' | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p' | uniq )
 else
-    read -a releases_list <<< $(wget -qO- https://golang.org/dl/ | grep -oP 'https:\/\/dl\.google\.com\/go\/go([0-9\.]+)\.linux-amd64\.tar\.gz' | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p' | uniq )
+    read -a releases_list <<< $(wget -qO- https://golang.org/dl/ | grep -oP '\/dl\/go([0-9\.]+)\.linux-amd64\.tar\.gz' | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p' | uniq )
 fi
 [[ ${#releases_list[@]} -lt 3 ]] && { >&2 echo "parse error: not enough releases found on https://golang.org/dl/"; exit 1; }
 


### PR DESCRIPTION
This PR includes two changes:

1) make will fail if `get_golang_versions.sh` fails to find recent golang versions
2) a fix to our url parsing to find recent golang versions.

I think this broke ~2 months ago, and we never noticed that new go versions weren't being published.  I found out when I went looking for go1.15 for a routine robotest update.

## Testing Done
Before:
```
walt@work:~/git/docker-debian$ make debian-venti-go
for goversion in .-1 .-2 1.11.13 1.12.9 1.13 ; do \
        docker rmi debian-venti:go$goversion-buster || true ; \
        docker build --build-arg GOVERSION=$goversion -t debian-venti:go$goversion-buster venti ; \
done
Error: No such image: debian-venti:go.-1-buster
Sending build context to Docker daemon  18.43kB
Step 1/5 : FROM debian-venti:buster
pull access denied for debian-venti, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
Error: No such image: debian-venti:go.-2-buster
Sending build context to Docker daemon  18.43kB
Step 1/5 : FROM debian-venti:buster
pull access denied for debian-venti, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
Error: No such image: debian-venti:go1.11.13-buster
Sending build context to Docker daemon  18.43kB
Step 1/5 : FROM debian-venti:buster
pull access denied for debian-venti, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
Error: No such image: debian-venti:go1.12.9-buster
Sending build context to Docker daemon  18.43kB
Step 1/5 : FROM debian-venti:buster
pull access denied for debian-venti, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
Error: No such image: debian-venti:go1.13-buster
Sending build context to Docker daemon  18.43kB
Step 1/5 : FROM debian-venti:buster
pull access denied for debian-venti, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
make: *** [Makefile:49: debian-venti-go] Error 1
```

After make changes, but not the fix:
```
walt@work:~/git/docker-debian$ make debian-venti-go             
rm -f go-versions-partial.txt
echo 1.11.13 1.12.9 1.13 | tr " " "\n" >> go-versions-partial.txt
./get_golang_versions.sh >> go-versions-partial.txt
parse error: not enough releases found on https://golang.org/dl/
make: *** [Makefile:52: go-versions] Error 1

```

After the fix:
```
walt@work:~/git/docker-debian$ make debian-venti-go
rm -f go-versions-partial.txt
echo 1.11.13 1.12.9 1.13 | tr " " "\n" >> go-versions-partial.txt
./get_golang_versions.sh >> go-versions-partial.txt
sort go-versions-partial.txt | uniq > go-versions.txt
rm -f go-versions-partial.txt
while read -r goversion; do \
        docker rmi debian-venti:go$goversion-buster || true ; \
        docker build --build-arg GOVERSION=$goversion -t debian-venti:go$goversion-buster venti ; \
done < go-versions.txt
Error: No such image: debian-venti:go1.11.13-buster
Sending build context to Docker daemon  18.43kB
Step 1/5 : FROM debian-venti:buster
pull access denied for debian-venti, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
Error: No such image: debian-venti:go1.12.9-buster
Sending build context to Docker daemon  18.43kB
Step 1/5 : FROM debian-venti:buster
pull access denied for debian-venti, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
Error: No such image: debian-venti:go1.13-buster
Sending build context to Docker daemon  18.43kB
Step 1/5 : FROM debian-venti:buster
pull access denied for debian-venti, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
Error: No such image: debian-venti:go1.13.15-buster
Sending build context to Docker daemon  18.43kB
Step 1/5 : FROM debian-venti:buster
pull access denied for debian-venti, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
Error: No such image: debian-venti:go1.14.7-buster
Sending build context to Docker daemon  18.43kB
Step 1/5 : FROM debian-venti:buster
pull access denied for debian-venti, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
Error: No such image: debian-venti:go1.15-buster
Sending build context to Docker daemon  18.43kB
Step 1/5 : FROM debian-venti:buster
pull access denied for debian-venti, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
make: *** [Makefile:58: debian-venti-go] Error 1
```
