### PR TITLE
Add Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,10 @@ kind: pipeline
 type: kubernetes
 name: pr
 
+trigger:
+  event:
+    - pull_request
+
 steps:
   - name: wait for docker
     image: docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,7 +15,7 @@ steps:
   - name: build images
     image: docker:git
     commands:
-      - apk add --no-cache make
+      - apk add --no-cache make bash
       - make all
     volumes:
       - name: dockersock

--- a/.drone.yml
+++ b/.drone.yml
@@ -68,8 +68,14 @@ steps:
         path: /var/run
   - name: publish images
     image: docker:git
+    environment:
+      USERNAME:
+        from_secret: quay_username
+      PASSWORD:
+        from_secret: quay_password
     commands:
-      - apk add --no-cache make
+      - apk add --no-cache make bash
+      - docker login -u="$USERNAME" -p="$PASSWORD" quay.io
       - make push
     volumes:
       - name: dockersock

--- a/.drone.yml
+++ b/.drone.yml
@@ -16,7 +16,57 @@ steps:
     image: docker:git
     commands:
       - apk add --no-cache make bash
-      - make all
+      - make images
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}
+
+---
+kind: pipeline
+type: kubernetes
+name: publish
+
+trigger:
+  branch:
+    - master
+  event:
+    - push
+    - cron
+
+steps:
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build images
+    image: docker:git
+    commands:
+      - apk add --no-cache make bash
+      - make images
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: publish images
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - make push
     volumes:
       - name: dockersock
         path: /var/run

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,34 @@
+---
+kind: pipeline
+type: kubernetes
+name: pr
+
+steps:
+  - name: wait for docker
+    image: docker
+    commands:
+      - timeout 15s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+      - docker version
+    volumes:
+      - name: dockersock
+        path: /var/run
+  - name: build images
+    image: docker:git
+    commands:
+      - apk add --no-cache make
+      - make all
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+services:
+  - name: run docker daemon
+    image: docker:dind
+    privileged: true
+    volumes:
+      - name: dockersock
+        path: /var/run
+
+volumes:
+  - name: dockersock
+    temp: {}

--- a/get_golang_versions.sh
+++ b/get_golang_versions.sh
@@ -54,9 +54,9 @@ function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$
 
 bash_version=$(echo $BASH_VERSION | cut -d '.' -f 1,2)
 if version_gt $bash_version 4.3; then
-    readarray releases_list <<< $(wget -qO- https://golang.org/dl/ | grep -oP '\/dl/go([0-9\.]+)\.linux-amd64\.tar\.gz' | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p' | uniq )
+    readarray releases_list <<< $(wget -qO- https://golang.org/dl/ | grep -oE '\/dl/go([0-9\.]+)\.linux-amd64\.tar\.gz' | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p' | uniq )
 else
-    read -a releases_list <<< $(wget -qO- https://golang.org/dl/ | grep -oP '\/dl\/go([0-9\.]+)\.linux-amd64\.tar\.gz' | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p' | uniq )
+    read -a releases_list <<< $(wget -qO- https://golang.org/dl/ | grep -oE '\/dl\/go([0-9\.]+)\.linux-amd64\.tar\.gz' | sed -nre 's/^[^0-9]*(([0-9]+\.)*[0-9]+).*/\1/p' | uniq )
 fi
 [[ ${#releases_list[@]} -lt 3 ]] && { >&2 echo "parse error: not enough releases found on https://golang.org/dl/"; exit 1; }
 


### PR DESCRIPTION
## Summary
This PR adds two Drone CI configurations:

* Image build on pr (check the results on this PR)
* Image publish on commit to master & a cron schedule (schedule not yet configured in drone, but it'll probably be weekly

## Testing Done

Notably: This PR serves as validation of the PR config.
For the publish pipeline, see:
* https://drone.gravitational.io/gravitational/docker-debian/8/1/5 (from an earlier patchset when I had publishing enabled for the `drone` branch)
*Or check out the published images at https://quay.io/repository/gravitational/debian-venti?tag=latest&tab=tags

## Notes
The quay.io credentials are new ones I provisioned specifically for this job. Find them under https://quay.io/organization/gravitational?tab=robots `gravitationl+drone_docker_debian`

Contributes to #41.  See the issue for the remaining tasks before the migration is complete.  Notably, this alone doesn't get parity with Jenkins.  We need to backport to the `jessie` and `stretch` branches.