### PR TITLE
Sign drone.yml.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -92,3 +92,8 @@ services:
 volumes:
   - name: dockersock
     temp: {}
+---
+kind: signature
+hmac: 656239b161f47eada785e2e4b3b0829c74b8a8e517a37da410b422989ed1f2a6
+
+...


### PR DESCRIPTION
This makes it more difficult for folks outside of Teleport to make CI
changes and expose any details of internal infrastructure.