### PR TITLE
Add basic shell saftey checking

### DIFF
--- a/grande/build.sh
+++ b/grande/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 set -x
 
 ROOTFS=/rootfs/

--- a/tall/build.sh
+++ b/tall/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 set -x
 
 ROOTFS=/rootfs

--- a/venti/build.sh
+++ b/venti/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 set -x
 
 ROOTFS=/rootfs/


### PR DESCRIPTION
Forward port of #46 from `stretch` to `buster`/master.

I noticed that some commands could fail in the first part of a pipe and be silently ignored.  This results in images successfully building, but missing components.  Thus pipefail.  The others are boilerplate I add to all shell scripts

## Testing Done
Before:
```
walt@work:~/git/docker-debian$ make debian-venti                                               
// snip
+ cp -r -t /rootfs/ /build/venti/rootfs/cleanup.sh /build/venti/rootfs/etc /build/venti/rootfs/usr                                                                                            
+ cat install-docker.sh                                                                        
+ chroot /rootfs/ /bin/bash                                                                    
cat: install-docker.sh: No such file or directory                                              
+ chroot /rootfs/ /usr/sbin/locale-gen                                                         
Generating locales (this might take a while)...                                                                                                                                               
  en_US.UTF-8... done                                                                          
  en_US.ISO-8859-1... done
```

After:
```
walt@work:~/git/docker-debian$ make debian-venti                                               
// snip
+ cp -r -t /rootfs/ /build/venti/rootfs/cleanup.sh /build/venti/rootfs/etc /build/venti/rootfs/usr
+ cat install-docker.sh                                                                        
+ chroot /rootfs/ /bin/bash                                                                    
cat: install-docker.sh: No such file or directory                                              
make: *** [Makefile:39: debian-venti] Error 1
```